### PR TITLE
Seeker Missile compatibility patch

### DIFF
--- a/lua/pewpewbullets/official_weapons/rockets/homingmissile.lua
+++ b/lua/pewpewbullets/official_weapons/rockets/homingmissile.lua
@@ -6,7 +6,7 @@ local BULLET = {}
 BULLET.Version = 2
 
 -- General Information
-BULLET.Name = "Homing Missile - Normal"
+BULLET.Name = "Seeker Missile"
 BULLET.Author = "Divran"
 BULLET.Description = "Fires homing missiles."
 BULLET.AdminOnly = false


### PR DESCRIPTION
Renames the homing missile - normal to the "Seeker Missile"

This should allow compatibility with any dupes that used the old homing missile on cfc2