### PR TITLE
Nebelwerfer Stat Adjustment.

### DIFF
--- a/lua/pewpewbullets/official_weapons/artilleries/Nebelwerfer.lua
+++ b/lua/pewpewbullets/official_weapons/artilleries/Nebelwerfer.lua
@@ -37,7 +37,7 @@ BULLET.Radius = 450
 BULLET.RangeDamageMul = 2.6
 BULLET.NumberOfSlices = nil
 BULLET.SliceDistance = nil
-BULLET.PlayerDamage = 40
+BULLET.PlayerDamage = 60
 BULLET.PlayerDamageRadius = 250
 
 -- Reloading/Ammo


### PR DESCRIPTION
Increased player damage to 60 (from 40) to improve reliability when landing two or more shots near a player.