### PR TITLE
Basic Cannon Stat Adjustment.

### DIFF
--- a/lua/pewpewbullets/official_weapons/cannons/basiccannon.lua
+++ b/lua/pewpewbullets/official_weapons/cannons/basiccannon.lua
@@ -38,7 +38,7 @@ BULLET.Radius = 400
 BULLET.RangeDamageMul = 2.2
 BULLET.NumberOfSlices = nil
 BULLET.SliceDistance = nil
-BULLET.PlayerDamage = 75
+BULLET.PlayerDamage = 110
 BULLET.PlayerDamageRadius = 150
 
 -- Reloading/Ammo


### PR DESCRIPTION
Increased damage to 110 from 75 to improve reliability and allow for 1 hit kills on direct impact shots.