### PR TITLE
Plasma Cannon Stat Adjustment.

### DIFF
--- a/lua/pewpewbullets/official_weapons/cannons/plasma_bomb.lua
+++ b/lua/pewpewbullets/official_weapons/cannons/plasma_bomb.lua
@@ -40,7 +40,7 @@ BULLET.DamageType = "BlastDamage"
 BULLET.Damage = 140
 BULLET.Radius = 250
 BULLET.RangeDamageMul = 2.2
-BULLET.PlayerDamage = 99
+BULLET.PlayerDamage = 100
 BULLET.PlayerDamageRadius = 100
 
 -- Reload/Ammo


### PR DESCRIPTION
Increased damage from 99 to 100 to allow for 1 hit kills on direct impact shots.