### PR TITLE
Grenade Launcher Stat Adjustment.

### DIFF
--- a/lua/pewpewbullets/official_weapons/launchers_and_spawners/grenadelauncher.lua
+++ b/lua/pewpewbullets/official_weapons/launchers_and_spawners/grenadelauncher.lua
@@ -39,7 +39,7 @@ BULLET.DamageType = "BlastDamage"
 BULLET.Damage = 275
 BULLET.Radius = 200
 BULLET.RangeDamageMul = 2.6
-BULLET.PlayerDamage = 50
+BULLET.PlayerDamage = 75
 BULLET.PlayerDamageRadius = 100
 
 -- Reloading/Ammo


### PR DESCRIPTION
Increased player damage to 75 from 50 to improve reliability of two hit kills.