### PR TITLE
Stickybomb Launcher Rename.

### DIFF
--- a/lua/pewpewbullets/official_weapons/other/DelayedStickyBombLauncher.lua
+++ b/lua/pewpewbullets/official_weapons/other/DelayedStickyBombLauncher.lua
@@ -6,7 +6,7 @@ local BULLET = {}
 BULLET.Version = 2
 
 -- General Information
-BULLET.Name = "Delayed Sticky-Bomb Launcher (DO NOT SPAWN)"
+BULLET.Name = "Delayed Sticky-Bomb Launcher (Restricted)"
 BULLET.Author = "Free Fall"
 BULLET.Description = "Fires a bomb that will stick to whatever it hits and explodes short time after"
 BULLET.AdminOnly = false


### PR DESCRIPTION
Changes (Do not spawn) to (Restricted) to better represent what it means.