### PR TITLE
flakcannon stat adjustment.

### DIFF
--- a/lua/pewpewbullets/official_weapons/cannons/Flak_cannon.lua
+++ b/lua/pewpewbullets/official_weapons/cannons/Flak_cannon.lua
@@ -41,7 +41,7 @@ BULLET.RangeDamageMul = 2
 BULLET.NumberOfSlices = nil
 BULLET.SliceDistance = nil
 BULLET.PlayerDamage = 100
-BULLET.PlayerDamageRadius = 500
+BULLET.PlayerDamageRadius = 350
 
 -- Reloading/Ammo
 BULLET.Reloadtime = 2


### PR DESCRIPTION
Reduces player radius to comparable size to a similarly sized cannon, but with greater range.